### PR TITLE
Set default value of `isScrolling` prop of `Canvas` when `undefined`

### DIFF
--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -106,7 +106,7 @@ const Viewport = React.createClass({
           rowSelection={this.props.rowSelection}
           getSubRowDetails={this.props.getSubRowDetails}
           rowGroupRenderer={this.props.rowGroupRenderer}
-          isScrolling={this.state.isScrolling}
+          isScrolling={this.state.isScrolling || false}
         />
       </div>
     );


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/adazzle/react-data-grid/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Rendering:

```js
<ReactDataGrid
  columns={columns}
  rowGetter={(index) => this.state.rows[index]}
  rowsCount={this.state.rows.length}
  minHeight={500}
  onGridSort={this.handleSort}
/>
```

results in the following errors:

```
[Error] Warning: Failed propType: Required prop `isScrolling` was not specified in `Row`. Check the render method of `Canvas`.
[Error] Warning: Failed propType: Required prop `isScrolling` was not specified in `Cell`. Check the render method of `Row`.
```

**What is the new behavior?**

No more errors

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Closes https://github.com/adazzle/react-data-grid/issues/520